### PR TITLE
update for twc 0.5.1 / 0.5.2

### DIFF
--- a/generators/element/templates/Develop.md
+++ b/generators/element/templates/Develop.md
@@ -9,14 +9,17 @@ The [TWC Wiki](https://github.com/Draccoz/twc/wiki) has much more information on
 ## Building <%= name %>
 To build `<%= name %>` just enter the project root dir and execute the following in the terminal:
 ```
-twc
+npm run twc
 ```
-It works just as tsc, reading configuration from tsconfig.json file. The only difference is it outputs .html files with Polymer module instead of plain .js.  In this case you will get a file, `<%= name %>.html` which is an ordinary Polymer 2.0 format element.
+It works just as tsc, reading configuration from tsconfig.json file. The only difference is it outputs .html files with Polymer modules instead of plain .js.  In this case you will get a file, `<%= name %>.html` which is an ordinary Polymer 2.0 format element.
 
 ## Generating Types for Polymer Elements
-You may be including other Polymer Elements in your project. To generate Typescript definition files for those elements, first install them (`bower install --save ...`), then run the `potts` command. 
+You may be including other Polymer Elements in your project. To generate Typescript definition files for those elements, first install them (`bower install --save ...`), then run the `potts` command:
+```
+npm run potts
+```
 
-`potts` will generate typings for Polymer elements in `bower.json` and save the typings to the `potts.d.ts` file in the root of your project. You can add that file to the `include` section of your `tsconfig.json`.
+`potts` will generate basic typings for all of the Polymer elements in `bower.json` and save the typings to the `potts.d.ts` file in the root of your project. You can add that file to the `include` section of your `tsconfig.json`.
 
 ## Serve Locally
 

--- a/generators/element/templates/package.json
+++ b/generators/element/templates/package.json
@@ -4,7 +4,9 @@
     "description": "<%= description %>",
     "main": "index.html",
     "scripts": {
-      "test": "echo \"Error: no test specified\" && exit 1"
+      "test": "echo \"Error: no test specified\" && exit 1",
+      "potts":"potts",
+      "twc": "twc"
     },
     "keywords": [
       "polymer",
@@ -16,8 +18,9 @@
     "license": "ISC",
     "devDependencies": {
       "potts": "^1.2.1",
-      "twc": "^0.4.2-rc",
-      "typescript": "^2.4.2",
+      "twc": "^0.5.2",
+      "typescript": "^2.6.2",
+      "polymer2-types": "^2.0.0",
       "@types/mocha": "^2.2.43"
     }
   }

--- a/generators/element/templates/tsconfig.json
+++ b/generators/element/templates/tsconfig.json
@@ -58,7 +58,8 @@
     "watch": true
     },
     "include": [
-     "node_modules/twc/types/polymer.decorators.d.ts",
+     "node_modules/twc/decorators/polymer.d.ts",
+     "node_modules/polymer2-types/*.d.ts",
      "./*.ts",
      "test/**/*.ts",
      "demo/**/*.ts"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-polymer-init-twc-element",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -19,9 +19,9 @@
       }
     },
     "@types/node": {
-      "version": "8.0.26",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.26.tgz",
-      "integrity": "sha512-wbKN0MB4XsjdnSE04HiCzLoBDirGCM6zXrqavSj44nZnPFYpnrTF64E9O6Xmf0ca/IuKK/BHUcXwMiwk92gW6Q=="
+      "version": "8.0.57",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.57.tgz",
+      "integrity": "sha512-ZxrhcBxlZA7tn0HFf7ebUYfR9aHyBgjyavBLzyrYMYuAMbONBPY4S5O35562iV2FfwnZCjQky3gTDy1B3jSZ2Q=="
     },
     "@types/rx": {
       "version": "4.1.1",
@@ -30,7 +30,7 @@
       "requires": {
         "@types/rx-core": "4.0.3",
         "@types/rx-core-binding": "4.0.4",
-        "@types/rx-lite": "4.0.4",
+        "@types/rx-lite": "4.0.5",
         "@types/rx-lite-aggregates": "4.0.3",
         "@types/rx-lite-async": "4.0.2",
         "@types/rx-lite-backpressure": "4.0.3",
@@ -56,9 +56,9 @@
       }
     },
     "@types/rx-lite": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@types/rx-lite/-/rx-lite-4.0.4.tgz",
-      "integrity": "sha1-cQ6/idCi1ZbCEEfZGxJCvO9Rwws=",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/rx-lite/-/rx-lite-4.0.5.tgz",
+      "integrity": "sha512-KZk5XTR1dm/kNgBx8iVpjno6fRYtAUQWBOmj+O8j724+nk097sz4fOoHJNpCkOJUtHUurZlJC7QvSFCZHbkC+w==",
       "requires": {
         "@types/rx-core": "4.0.3",
         "@types/rx-core-binding": "4.0.4"
@@ -69,7 +69,7 @@
       "resolved": "https://registry.npmjs.org/@types/rx-lite-aggregates/-/rx-lite-aggregates-4.0.3.tgz",
       "integrity": "sha512-MAGDAHy8cRatm94FDduhJF+iNS5//jrZ/PIfm+QYw9OCeDgbymFHChM8YVIvN2zArwsRftKgE33QfRWvQk4DPg==",
       "requires": {
-        "@types/rx-lite": "4.0.4"
+        "@types/rx-lite": "4.0.5"
       }
     },
     "@types/rx-lite-async": {
@@ -77,7 +77,7 @@
       "resolved": "https://registry.npmjs.org/@types/rx-lite-async/-/rx-lite-async-4.0.2.tgz",
       "integrity": "sha512-vTEv5o8l6702ZwfAM5aOeVDfUwBSDOs+ARoGmWAKQ6LOInQ8J4/zjM7ov12fuTpktUKdMQjkeCp07Vd73mPkxw==",
       "requires": {
-        "@types/rx-lite": "4.0.4"
+        "@types/rx-lite": "4.0.5"
       }
     },
     "@types/rx-lite-backpressure": {
@@ -85,7 +85,7 @@
       "resolved": "https://registry.npmjs.org/@types/rx-lite-backpressure/-/rx-lite-backpressure-4.0.3.tgz",
       "integrity": "sha512-Y6aIeQCtNban5XSAF4B8dffhIKu6aAy/TXFlScHzSxh6ivfQBQw6UjxyEJxIOt3IT49YkS+siuayM2H/Q0cmgA==",
       "requires": {
-        "@types/rx-lite": "4.0.4"
+        "@types/rx-lite": "4.0.5"
       }
     },
     "@types/rx-lite-coincidence": {
@@ -93,7 +93,7 @@
       "resolved": "https://registry.npmjs.org/@types/rx-lite-coincidence/-/rx-lite-coincidence-4.0.3.tgz",
       "integrity": "sha512-1VNJqzE9gALUyMGypDXZZXzR0Tt7LC9DdAZQ3Ou/Q0MubNU35agVUNXKGHKpNTba+fr8GdIdkC26bRDqtCQBeQ==",
       "requires": {
-        "@types/rx-lite": "4.0.4"
+        "@types/rx-lite": "4.0.5"
       }
     },
     "@types/rx-lite-experimental": {
@@ -101,7 +101,7 @@
       "resolved": "https://registry.npmjs.org/@types/rx-lite-experimental/-/rx-lite-experimental-4.0.1.tgz",
       "integrity": "sha1-xTL1y98/LBXaFt7Ykw0bKYQCPL0=",
       "requires": {
-        "@types/rx-lite": "4.0.4"
+        "@types/rx-lite": "4.0.5"
       }
     },
     "@types/rx-lite-joinpatterns": {
@@ -109,7 +109,7 @@
       "resolved": "https://registry.npmjs.org/@types/rx-lite-joinpatterns/-/rx-lite-joinpatterns-4.0.1.tgz",
       "integrity": "sha1-9w/jcFGKhDLykVjMkv+1a05K/D4=",
       "requires": {
-        "@types/rx-lite": "4.0.4"
+        "@types/rx-lite": "4.0.5"
       }
     },
     "@types/rx-lite-testing": {
@@ -125,7 +125,7 @@
       "resolved": "https://registry.npmjs.org/@types/rx-lite-time/-/rx-lite-time-4.0.3.tgz",
       "integrity": "sha512-ukO5sPKDRwCGWRZRqPlaAU0SKVxmWwSjiOrLhoQDoWxZWg6vyB9XLEZViKOzIO6LnTIQBlk4UylYV0rnhJLxQw==",
       "requires": {
-        "@types/rx-lite": "4.0.4"
+        "@types/rx-lite": "4.0.5"
       }
     },
     "@types/rx-lite-virtualtime": {
@@ -133,7 +133,7 @@
       "resolved": "https://registry.npmjs.org/@types/rx-lite-virtualtime/-/rx-lite-virtualtime-4.0.3.tgz",
       "integrity": "sha512-3uC6sGmjpOKatZSVHI2xB1+dedgml669ZRvqxy+WqmGJDVusOdyxcKfyzjW0P3/GrCiN4nmRkLVMhPwHCc5QLg==",
       "requires": {
-        "@types/rx-lite": "4.0.4"
+        "@types/rx-lite": "4.0.5"
       }
     },
     "@types/through": {
@@ -141,21 +141,21 @@
       "resolved": "https://registry.npmjs.org/@types/through/-/through-0.0.29.tgz",
       "integrity": "sha512-9a7C5VHh+1BKblaYiq+7Tfc+EOmjMdZaD1MYtkQjSoxgB69tBjW98ry6SKsi4zEIWztLOMRuL87A3bdT/Fc/4w==",
       "requires": {
-        "@types/node": "8.0.26"
+        "@types/node": "8.0.57"
       }
     },
     "@types/yeoman-generator": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@types/yeoman-generator/-/yeoman-generator-1.0.3.tgz",
-      "integrity": "sha512-twfjJOWO2Rf1JAq5qPPe0mc7eHe1lRuz3RVTuekYkZQFF0Y6br9rGpMI1osxnIxBGBzpl47lSE/OFBoo1EFzfw==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@types/yeoman-generator/-/yeoman-generator-1.0.4.tgz",
+      "integrity": "sha512-iMm6ZU90vgupfqIDMQSSKh7VfM3susAoXx8Zv79FGnpiExtUTq8HeAg0AlrwqeP00VpPO/x/ytNejmmyuNoT/A==",
       "requires": {
         "@types/inquirer": "0.0.35"
       }
     },
     "abbrev": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
-      "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true
     },
     "ansi-escapes": {
@@ -173,7 +173,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
       "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
       "requires": {
-        "color-convert": "1.9.0"
+        "color-convert": "1.9.1"
       }
     },
     "array-differ": {
@@ -200,9 +200,9 @@
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
     },
     "async": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
-      "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+      "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
       "requires": {
         "lodash": "4.17.4"
       }
@@ -218,9 +218,9 @@
       "integrity": "sha1-5ZfRp6ajVYotHHJBoWyZll5qpA8="
     },
     "bluebird": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
-      "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw=",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
       "dev": true
     },
     "brace-expansion": {
@@ -243,13 +243,13 @@
       "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0="
     },
     "chalk": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
-      "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+      "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
       "requires": {
         "ansi-styles": "3.2.0",
         "escape-string-regexp": "1.0.5",
-        "supports-color": "4.4.0"
+        "supports-color": "4.5.0"
       }
     },
     "class-extend": {
@@ -301,7 +301,7 @@
       "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.0.0.tgz",
       "integrity": "sha1-pikNQT8hemEjL5XkWP84QYz7ARc=",
       "requires": {
-        "inherits": "2.0.3",
+        "inherits": "2.0.1",
         "process-nextick-args": "1.0.7",
         "through2": "2.0.3"
       }
@@ -312,9 +312,9 @@
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
     "color-convert": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
-      "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
       "requires": {
         "color-name": "1.1.3"
       }
@@ -330,9 +330,9 @@
       "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
     },
     "commander": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
+      "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
       "dev": true
     },
     "commondir": {
@@ -353,6 +353,13 @@
         "inherits": "2.0.3",
         "readable-stream": "2.3.3",
         "typedarray": "0.0.6"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+        }
       }
     },
     "condense-newlines": {
@@ -372,7 +379,7 @@
       "integrity": "sha1-q6CXR9++TD5w52am5BWG4YWfxvI=",
       "dev": true,
       "requires": {
-        "ini": "1.3.4",
+        "ini": "1.3.5",
         "proto-list": "1.2.4"
       }
     },
@@ -397,17 +404,6 @@
         "lru-cache": "4.1.1",
         "shebang-command": "1.2.0",
         "which": "1.3.0"
-      },
-      "dependencies": {
-        "lru-cache": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-          "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
-          "requires": {
-            "pseudomap": "1.0.2",
-            "yallist": "2.1.2"
-          }
-        }
       }
     },
     "dargs": {
@@ -416,14 +412,14 @@
       "integrity": "sha1-7H6lDHhWTNNsnV7Bj2Yyn63ieCk="
     },
     "dateformat": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.0.0.tgz",
-      "integrity": "sha1-J0Pjq7XD/CRi5SfcpEXgTp9N7hc="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
+      "integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI="
     },
     "debug": {
-      "version": "2.6.8",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "requires": {
         "ms": "2.0.0"
       }
@@ -459,11 +455,22 @@
       "integrity": "sha512-WkjsUNVCu+ITKDj73QDvi0trvpdDWdkDyHybDGSXPfekLCqwmpD7CP7iPbvBgosNuLcI96XTDwNa75JyFl7tEQ==",
       "dev": true,
       "requires": {
-        "bluebird": "3.5.0",
-        "commander": "2.11.0",
+        "bluebird": "3.5.1",
+        "commander": "2.12.2",
         "lru-cache": "3.2.0",
         "semver": "5.4.1",
         "sigmund": "1.0.1"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-3.2.0.tgz",
+          "integrity": "sha1-cXibO39Tmb7IVl3aOKow0qCX7+4=",
+          "dev": true,
+          "requires": {
+            "pseudomap": "1.0.2"
+          }
+        }
       }
     },
     "ejs": {
@@ -588,7 +595,7 @@
       "requires": {
         "fs.realpath": "1.0.0",
         "inflight": "1.0.6",
-        "inherits": "2.0.3",
+        "inherits": "2.0.1",
         "minimatch": "3.0.4",
         "once": "1.4.0",
         "path-is-absolute": "1.0.1"
@@ -672,14 +679,14 @@
       }
     },
     "inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+      "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
     },
     "ini": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-      "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
       "dev": true
     },
     "inquirer": {
@@ -728,9 +735,9 @@
       }
     },
     "interpret": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz",
-      "integrity": "sha1-y8NcYu7uc/Gat7EKgBURQBr8D5A="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
+      "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ="
     },
     "is-arrayish": {
       "version": "0.2.1",
@@ -738,9 +745,9 @@
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
     },
     "is-buffer": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
-      "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "dev": true
     },
     "is-builtin-module": {
@@ -822,9 +829,9 @@
       }
     },
     "js-beautify": {
-      "version": "1.6.14",
-      "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.6.14.tgz",
-      "integrity": "sha1-07j3Mi0CuSd9WL0jgmTDJ+WARM0=",
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.7.5.tgz",
+      "integrity": "sha512-9OhfAqGOrD7hoQBLJMTA+BKuKmoEtTJXzZ7WDF/9gvjtey1koVLuZqIY6c51aPDjbNdNtIXAkiWKVhziawE9Og==",
       "dev": true,
       "requires": {
         "config-chain": "1.1.11",
@@ -839,7 +846,7 @@
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
       "requires": {
-        "is-buffer": "1.1.5"
+        "is-buffer": "1.1.6"
       }
     },
     "load-json-file": {
@@ -905,12 +912,12 @@
       "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY="
     },
     "lru-cache": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-3.2.0.tgz",
-      "integrity": "sha1-cXibO39Tmb7IVl3aOKow0qCX7+4=",
-      "dev": true,
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+      "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
       "requires": {
-        "pseudomap": "1.0.2"
+        "pseudomap": "1.0.2",
+        "yallist": "2.1.2"
       }
     },
     "mem-fs": {
@@ -924,9 +931,9 @@
       },
       "dependencies": {
         "clone": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
-          "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk="
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.3.tgz",
+          "integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8="
         },
         "clone-stats": {
           "version": "0.0.1",
@@ -943,7 +950,7 @@
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
           "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
           "requires": {
-            "clone": "1.0.2",
+            "clone": "1.0.3",
             "clone-stats": "0.0.1",
             "replace-ext": "0.0.1"
           }
@@ -962,7 +969,7 @@
         "globby": "6.1.0",
         "mkdirp": "0.5.1",
         "multimatch": "2.1.0",
-        "rimraf": "2.6.1",
+        "rimraf": "2.6.2",
         "through2": "2.0.3",
         "vinyl": "2.1.0"
       }
@@ -976,9 +983,9 @@
       }
     },
     "minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "mkdirp": {
       "version": "0.5.1",
@@ -986,6 +993,13 @@
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+        }
       }
     },
     "ms": {
@@ -1015,7 +1029,7 @@
       "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
       "dev": true,
       "requires": {
-        "abbrev": "1.1.0"
+        "abbrev": "1.1.1"
       }
     },
     "normalize-package-data": {
@@ -1151,7 +1165,7 @@
       "requires": {
         "condense-newlines": "0.2.1",
         "extend-shallow": "2.0.1",
-        "js-beautify": "1.6.14"
+        "js-beautify": "1.7.5"
       }
     },
     "pretty-bytes": {
@@ -1227,6 +1241,13 @@
         "safe-buffer": "5.1.1",
         "string_decoder": "1.0.3",
         "util-deprecate": "1.0.2"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+        }
       }
     },
     "rechoir": {
@@ -1234,7 +1255,7 @@
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "requires": {
-        "resolve": "1.4.0"
+        "resolve": "1.5.0"
       }
     },
     "remove-trailing-separator": {
@@ -1248,9 +1269,9 @@
       "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
     },
     "resolve": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
-      "integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
+      "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
       "requires": {
         "path-parse": "1.0.5"
       }
@@ -1265,9 +1286,9 @@
       }
     },
     "rimraf": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-      "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "requires": {
         "glob": "7.1.2"
       }
@@ -1314,7 +1335,7 @@
       "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
       "requires": {
         "glob": "7.1.2",
-        "interpret": "1.0.3",
+        "interpret": "1.1.0",
         "rechoir": "0.6.2"
       }
     },
@@ -1407,9 +1428,9 @@
       }
     },
     "supports-color": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-      "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+      "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
       "requires": {
         "has-flag": "2.0.0"
       }
@@ -1452,9 +1473,9 @@
       }
     },
     "twc": {
-      "version": "0.4.2-rc",
-      "resolved": "https://registry.npmjs.org/twc/-/twc-0.4.2-rc.tgz",
-      "integrity": "sha512-v2bRW56phGC0uOw/MTFpDdfw4vogUZo9Lapj1oTXQloK9u15WvB+L5uBEWH0r6GrbSTfZo/e7ULls1teHp24pQ==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/twc/-/twc-0.5.2.tgz",
+      "integrity": "sha1-izPUJH4SA2CCVU09spk26gDp23w=",
       "dev": true,
       "requires": {
         "pretty": "2.0.0",
@@ -1475,9 +1496,9 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typescript": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.5.2.tgz",
-      "integrity": "sha1-A4qV99m7tCCxvzW6MdTFwd0//jQ=",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.2.tgz",
+      "integrity": "sha1-PFtv1/beCRQmkCfwPAlGdY92c6Q=",
       "dev": true
     },
     "untildify": {
@@ -1515,13 +1536,6 @@
       "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
       "requires": {
         "inherits": "2.0.1"
-      },
-      "dependencies": {
-        "inherits": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
-        }
       }
     },
     "util-deprecate": {
@@ -1565,9 +1579,9 @@
       },
       "dependencies": {
         "clone": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
-          "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk="
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.3.tgz",
+          "integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8="
         },
         "clone-stats": {
           "version": "0.0.1",
@@ -1592,7 +1606,7 @@
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
           "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
           "requires": {
-            "clone": "1.0.2",
+            "clone": "1.0.3",
             "clone-stats": "0.0.1",
             "replace-ext": "0.0.1"
           }
@@ -1628,7 +1642,7 @@
       "integrity": "sha1-zYX6Z9FWBg5EDXgH1+988NLR1nE=",
       "requires": {
         "chalk": "1.1.3",
-        "debug": "2.6.8",
+        "debug": "2.6.9",
         "diff": "2.2.3",
         "escape-string-regexp": "1.0.5",
         "globby": "4.1.0",
@@ -1664,7 +1678,7 @@
           "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
           "requires": {
             "inflight": "1.0.6",
-            "inherits": "2.0.3",
+            "inherits": "2.0.1",
             "minimatch": "3.0.4",
             "once": "1.4.0",
             "path-is-absolute": "1.0.1"
@@ -1700,14 +1714,14 @@
       "resolved": "https://registry.npmjs.org/yeoman-generator/-/yeoman-generator-1.1.1.tgz",
       "integrity": "sha1-QMK09s374F4ZUv3XKTPw2JJdvfU=",
       "requires": {
-        "async": "2.5.0",
+        "async": "2.6.0",
         "chalk": "1.1.3",
         "class-extend": "0.1.2",
         "cli-table": "0.3.1",
         "cross-spawn": "5.1.0",
         "dargs": "5.1.0",
-        "dateformat": "2.0.0",
-        "debug": "2.6.8",
+        "dateformat": "2.2.0",
+        "debug": "2.6.9",
         "detect-conflict": "1.0.1",
         "error": "7.0.2",
         "find-up": "2.1.0",
@@ -1723,7 +1737,7 @@
         "pretty-bytes": "4.0.2",
         "read-chunk": "2.1.0",
         "read-pkg-up": "2.0.0",
-        "rimraf": "2.6.1",
+        "rimraf": "2.6.2",
         "run-async": "2.3.0",
         "shelljs": "0.7.8",
         "text-table": "0.2.0",
@@ -1748,11 +1762,6 @@
             "strip-ansi": "3.0.1",
             "supports-color": "2.0.0"
           }
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         },
         "supports-color": {
           "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-polymer-init-twc-element",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Polymer 2 element in Typescript using TWC",
   "main": "index.js",
   "repository": {
@@ -27,8 +27,8 @@
     "generators/element"
   ],
   "devDependencies": {
-    "twc": "^0.4.2-rc",
-    "typescript": "^2.5.2"
+    "twc": "^0.5.2",
+    "typescript": "^2.6.2"
   },
   "dependencies": {
     "@types/chalk": "^0.4.31",


### PR DESCRIPTION
Updates the generator to use twc 0.5.2 and includes twc setup changes from the 0.5.1 release - `twc/decorators/polymer.d.ts` instead of `twc/types/polymer.decorators.d.ts` and inclusion of `polymer2-types`.